### PR TITLE
This fixes issues with Django 1.5. django.http.get_host()

### DIFF
--- a/django_cas/views.py
+++ b/django_cas/views.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from urllib import urlencode
 from urlparse import urljoin
 
-from django.http import get_host, HttpResponseRedirect, HttpResponseForbidden, HttpResponse
+from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -15,7 +15,7 @@ def _service_url(request, redirect_to=None):
     """Generates application service URL for CAS"""
 
     protocol = ('http://', 'https://')[request.is_secure()]
-    host = get_host(request)
+    host = request.get_host()
     service = protocol + host + request.path
     if redirect_to:
         if '?' in service:
@@ -38,7 +38,7 @@ def _redirect_url(request):
         else:
             next = request.META.get('HTTP_REFERER', settings.CAS_REDIRECT_URL)
         prefix = (('http://', 'https://')[request.is_secure()] +
-                  get_host(request))
+                  request.get_host())
         if next.startswith(prefix):
             next = next[len(prefix):]
     return next
@@ -63,7 +63,7 @@ def _logout_url(request, next_page=None):
     url = urljoin(settings.CAS_SERVER_URL, 'logout')
     if next_page:
         protocol = ('http://', 'https://')[request.is_secure()]
-        host = get_host(request)
+        host = request.get_host()
         url += '?' + urlencode({'url': protocol + host + next_page})
     return url
 


### PR DESCRIPTION
This fixes issues with Django 1.5. django.http.get_host() was replaced with request.get_host()
