### PR TITLE
CAS 3.0 support

### DIFF
--- a/django_cas/backends.py
+++ b/django_cas/backends.py
@@ -110,7 +110,38 @@ def verify_proxy_ticket(ticket, service):
         page.close()
     
 
-_PROTOCOLS = {'1': _verify_cas1, '2': _verify_cas2}
+def _verify_cas3(ticket, service):
+    """Verifies CAS 3.0+ XML-based authentication ticket and returns extended attributes.
+    Returns username on success and None on failure.
+    """
+
+    try:
+        from xml.etree import ElementTree
+    except ImportError:
+        from elementtree import ElementTree
+
+    params = {'ticket': ticket, 'service': service}
+    url = (urljoin(settings.CAS_SERVER_URL, 'proxyValidate') + '?' +
+           urlencode(params))
+    page = urlopen(url)
+    try:
+        user = None
+        attributes = {}
+        response = page.read()
+        tree = ElementTree.fromstring(response)
+        if tree[0].tag.endswith('authenticationSuccess'):
+            for element in tree[0]:
+               if element.tag.endswith('user'):
+                    user = element.text
+               elif element.tag.endswith('attributes'):
+                    for attribute in element:
+                        attributes[attribute.tag.split("}").pop()] = attribute.text
+        return user, attributes
+    finally:
+        page.close()
+
+
+_PROTOCOLS = {'1': _verify_cas1, '2': _verify_cas2, '3': _verify_cas3}
 
 if settings.CAS_VERSION not in _PROTOCOLS:
     raise ValueError('Unsupported CAS_VERSION %r' % settings.CAS_VERSION)


### PR DESCRIPTION
CAS 3.0 support

To support CAS 3.0,the attribute mapper should be like:
@carsongee 

``` python

def populate_user(user, authentication_response):
    if authentication_response is not None:
        if authentication_response.has_key('is_superuser'):
            user.is_superuser = authentication_response['is_superuser']

        if authentication_response.has_key('is_staff'):
            user.is_staff = authentication_response['is_staff']

        if authentication_response.has_key('givenName'):
            user.first_name = authentication_response['givenName']

        if authentication_response.has_key('sn'):
            user.last_name = authentication_response['sn']

        if authentication_response.has_key('email'):
            user.email = authentication_response['email']

    pass
```
